### PR TITLE
Add fix for asset selection when camera button is OFF

### DIFF
--- a/GMImagePicker/GMGridViewController.m
+++ b/GMImagePicker/GMGridViewController.m
@@ -605,6 +605,14 @@ NSString * const CameraCellIdentifier = @"CameraCellIdentifier";
                 }
             }
         }
+    } else {
+        if (indexPath.item) {
+            PHAsset *asset = self.assetsFetchResults[indexPath.item];
+            [self.picker selectAsset:asset];
+            if ([self.picker.delegate respondsToSelector:@selector(assetsPickerController:didSelectAsset:)]) {
+                [self.picker.delegate assetsPickerController:self.picker didSelectAsset:asset];
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix for using the picker when use camera is OFF so first item in photo gallery in no longer the camera button.